### PR TITLE
Fix variable name typo

### DIFF
--- a/gcodeplot.py
+++ b/gcodeplot.py
@@ -596,7 +596,7 @@ def parseSVG(svgTree, tolerance=0.05, shader=None, strokeAll=False, pens=None, e
             del data[strokePen]
 
         if shader is not None and shader.isActive() and path.svgState.fill is not None and (extractColor is None or
-                isSameColor(path.svgStatefill, extractColor)):
+                isSameColor(path.svgState.fill, extractColor)):
             pen = getPen(pens, path.svgState.fill)
 
             if pen not in data:


### PR DESCRIPTION
I was having issues splitting up my SVG by colors. Kept getting an error that `path.svgStatefill` was not a property. I think this was a typo and should be `path.svgState.fill`. This patch fixed my use case.